### PR TITLE
Be less sensitive regarding whitespace in JSON files

### DIFF
--- a/coverage.el
+++ b/coverage.el
@@ -165,8 +165,8 @@ root."
   (with-temp-buffer
     (insert-file-contents filepath)
     (goto-char (point-max))
-    (re-search-backward "\"timestamp\": [0-9]+")
-    (re-search-forward ": ")
+    (re-search-backward "\"timestamp\": *[0-9]+")
+    (re-search-forward ": *")
     (current-word)))
 
 (defun coverage-get-timestamp-for-current-buffer ()


### PR DESCRIPTION
This is a hopefully temporary band-aid over the bigger problem that we really should not be parsing JSON with regular expressions.